### PR TITLE
Fixes inconsistencies in (milli)seconds in LeakyBucketThrottler.

### DIFF
--- a/src/Throttle/Settings/LeakyBucketSettings.php
+++ b/src/Throttle/Settings/LeakyBucketSettings.php
@@ -88,8 +88,7 @@ final class LeakyBucketSettings implements ThrottleSettingsInterface
         return
             null !== $this->tokenLimit &&
             null !== $this->timeLimit &&
-            0 !== $this->timeLimit &&
-            $this->tokenLimit !== $this->threshold;
+            0 !== $this->timeLimit;
     }
 
     /**

--- a/src/Time/PhpTimeAdapter.php
+++ b/src/Time/PhpTimeAdapter.php
@@ -28,11 +28,13 @@ namespace Sunspikes\Ratelimit\Time;
 final class PhpTimeAdapter implements TimeAdapterInterface
 {
     /**
-     * @return int
+     * @return float
      */
     public function now()
     {
-        return time();
+        list($usec, $sec) = explode(" ", microtime());
+
+        return ((float) $usec + (float) $sec);
     }
 
     /**

--- a/src/Time/TimeAdapterInterface.php
+++ b/src/Time/TimeAdapterInterface.php
@@ -28,7 +28,7 @@ namespace Sunspikes\Ratelimit\Time;
 interface TimeAdapterInterface
 {
     /**
-     * @return int
+     * @return float
      */
     public function now();
 

--- a/tests/Functional/LeakyBucketTest.php
+++ b/tests/Functional/LeakyBucketTest.php
@@ -69,7 +69,7 @@ class LeakyBucketTest extends \PHPUnit_Framework_TestCase
     public function testThrottleAccess()
     {
         $expectedWaitTime = self::TIME_LIMIT / (self::TOKEN_LIMIT - self::THRESHOLD);
-        $this->timeAdapter->shouldReceive('usleep')->with(1e3 * $expectedWaitTime)->once();
+        $this->timeAdapter->shouldReceive('usleep')->with($expectedWaitTime)->once();
 
         $throttle = $this->ratelimiter->get('access-test');
         $throttle->access();

--- a/tests/Throttle/Settings/LeakyBucketSettingsTest.php
+++ b/tests/Throttle/Settings/LeakyBucketSettingsTest.php
@@ -54,7 +54,7 @@ class LeakyBucketSettingsTest extends \PHPUnit_Framework_TestCase
             [null, 600, null, false],
             [3, null, null, false],
             [3, 0, null, false],
-            [3, 600, 3, false],
+            [3, 600, 3, true],
             [30, 600, 15, true],
         ];
     }

--- a/tests/Throttle/Throttler/LeakyBucketThrottlerTest.php
+++ b/tests/Throttle/Throttler/LeakyBucketThrottlerTest.php
@@ -55,7 +55,7 @@ class LeakyBucketThrottlerTest extends \PHPUnit_Framework_TestCase
     {
         //More time has passed than the given window
         $this->mockTimePassed(self::TIME_LIMIT + 1, 2);
-        $this->mockSetUsedCapacity(1, self::INITIAL_TIME + self::TIME_LIMIT + 1);
+        $this->mockSetUsedCapacity(1, (self::INITIAL_TIME + self::TIME_LIMIT + 1) / 1e3);
 
         $this->assertEquals(true, $this->throttler->access());
     }
@@ -90,7 +90,7 @@ class LeakyBucketThrottlerTest extends \PHPUnit_Framework_TestCase
         $this->mockSetUsedCapacity(self::THRESHOLD + 1, self::INITIAL_TIME);
 
         $expectedWaitTime = self::TIME_LIMIT / (self::TOKEN_LIMIT - self::THRESHOLD);
-        $this->timeAdapter->shouldReceive('usleep')->with(1e3 * $expectedWaitTime)->once();
+        $this->timeAdapter->shouldReceive('usleep')->with($expectedWaitTime)->once();
 
         $this->assertEquals($expectedWaitTime, $this->throttler->hit());
     }
@@ -167,11 +167,11 @@ class LeakyBucketThrottlerTest extends \PHPUnit_Framework_TestCase
      */
     private function mockTimePassed($timeDiff, $numCalls)
     {
-        $this->timeAdapter->shouldReceive('now')->times($numCalls)->andReturn(self::INITIAL_TIME + $timeDiff);
+        $this->timeAdapter->shouldReceive('now')->times($numCalls)->andReturn((self::INITIAL_TIME + $timeDiff) / 1e3);
 
         $this->cacheAdapter
             ->shouldReceive('get')
             ->with('key'.LeakyBucketThrottler::TIME_CACHE_KEY)
-            ->andReturn(self::INITIAL_TIME);
+            ->andReturn(self::INITIAL_TIME / 1e3);
     }
 }


### PR DESCRIPTION
Also fixes division by zero situation when tokenlimit == threshold